### PR TITLE
Exclude unused platform-specific tkdnd files in pyinstaller hook

### DIFF
--- a/hook-tkinterdnd2.py
+++ b/hook-tkinterdnd2.py
@@ -8,15 +8,21 @@ Just put hook-tkinterdnd2.py in the same directory where you call pyinstaller an
 
 import os
 import platform
-from PyInstaller.utils.hooks import collect_data_files
+from PyInstaller.utils.hooks import collect_data_files, collect_dynamic_libs
 
 s = platform.system()
 p = {
-    'Windows': 'win64',
-    'Linux': 'linux64',
-    'Darwin': 'osx64',
+    'Windows': ('win64', {'tkdnd_unix.tcl', 'tkdnd_macosx.tcl'}),
+    'Linux': ('linux64', {'tkdnd_windows.tcl', 'tkdnd_macosx.tcl'}),
+    'Darwin': ('osx64', {'tkdnd_windows.tcl', 'tkdnd_unix.tcl'}),
 }
 if s in p:
-    datas = [x for x in collect_data_files('tkinterdnd2') if os.path.split(x[1])[1] == p[s]]
+    datas = set([
+        x for x in (
+            *collect_data_files('tkinterdnd2'),
+            *collect_dynamic_libs('tkinterdnd2'),
+        )
+        if os.path.split(x[1])[1] == p[s][0] and os.path.split(x[0])[1] not in p[s][1]
+    ])
 else:
     raise RuntimeError(f'TkinterDnD2 is not supported on platform "{s}".')

--- a/hook-tkinterdnd2.py
+++ b/hook-tkinterdnd2.py
@@ -6,7 +6,17 @@ Just put hook-tkinterdnd2.py in the same directory where you call pyinstaller an
     pyinstaller myproject/myproject.py --additional-hooks-dir=.
 """
 
-from PyInstaller.utils.hooks import collect_data_files, eval_statement
+import os
+import platform
+from PyInstaller.utils.hooks import collect_data_files
 
-
-datas = collect_data_files('tkinterdnd2')
+s = platform.system()
+p = {
+    'Windows': 'win64',
+    'Linux': 'linux64',
+    'Darwin': 'osx64',
+}
+if s in p:
+    datas = [x for x in collect_data_files('tkinterdnd2') if os.path.split(x[1])[1] == p[s]]
+else:
+    raise RuntimeError(f'TkinterDnD2 is not supported on platform "{s}".')


### PR DESCRIPTION
The tkdnd folder contains pre-compiled files for Windows, Linux and macOS. But TkinterDnD.py only [loads one of them](https://github.com/Eliav2/tkinterdnd2/blob/99f2ba2b65ae4dae5a1aaa482484bfca59bf7f6f/tkinterdnd2/TkinterDnD.py#L42) according to current platform. I modified the pyinstaller hook to exclude the unused platform-specific tkdnd files so the bundled app's size can be slightly reduced.