### PR TITLE
Remove Tix support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
-## fork
+# TkinterDnD2 (Fork)
 
-this is fork of [tkinterdnd2](https://github.com/pmgagne/tkinterdnd2) which is a python wrapper for [tkdnd](https://github.com/petasis/tkdnd)
-.
+This is a fork in a long line of forks.
+The original [tkinterdnd2](https://github.com/pmgagne/tkinterdnd2) bt pmgagne became unmaintained and was forked by [Eliav2](https://github.com/Eliav2/tkinterdnd2) in order to be listed as a PyPI package. It too, unfortunately appears to have become unmaintained. This repository aims to maintain it at a minimum for my own purposes. I will be reviewing the improvement recommendations from the older repositories and implementing them here. Those recommendations (which were really reasonable) never were implemented nor even received comments in greater than 2 years. 
 
-this repo forked and edited to be published to pypi so one could simply install this package
-with  `pip install tkinterdnd2`.
+But what is the project really? `tkinterdnd2` is a wrapper for [tkdnd](https://github.com/petasis/tkdnd). TkDnD is the addition of Drag-and-Drop capabilities to Tk, a cross-platform toolki for making user-interfaces. TkinterDnD2 is then intended for implementing those drag-and-drop capabilities easily into Tkinter (and thus Python) GUI applications.
 
-## install
+This repository is not yet on PyPI, but may be in the future.
 
-`python -m pip install tkinterdnd2`
+The following is the documentation from previous versions of this project, and has yet to be updated:
 
 ## usage
 

--- a/README.md
+++ b/README.md
@@ -64,4 +64,3 @@ your project, then:
 
     pyinstaller -F -w myproject/myproject.py --additional-hooks-dir=.
 
-

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
-# TkinterDnD2 (Fork)
+## fork
 
-This is a fork in a long line of forks.
-The original [tkinterdnd2](https://github.com/pmgagne/tkinterdnd2) bt pmgagne became unmaintained and was forked by [Eliav2](https://github.com/Eliav2/tkinterdnd2) in order to be listed as a PyPI package. It too, unfortunately appears to have become unmaintained. This repository aims to maintain it at a minimum for my own purposes. I will be reviewing the improvement recommendations from the older repositories and implementing them here. Those recommendations (which were really reasonable) never were implemented nor even received comments in greater than 2 years. 
+this is fork of [tkinterdnd2](https://github.com/pmgagne/tkinterdnd2) which is a python wrapper for [tkdnd](https://github.com/petasis/tkdnd)
+.
 
-But what is the project really? `tkinterdnd2` is a wrapper for [tkdnd](https://github.com/petasis/tkdnd). TkDnD is the addition of Drag-and-Drop capabilities to Tk, a cross-platform toolki for making user-interfaces. TkinterDnD2 is then intended for implementing those drag-and-drop capabilities easily into Tkinter (and thus Python) GUI applications.
+this repo forked and edited to be published to pypi so one could simply install this package
+with  `pip install tkinterdnd2`.
 
-This repository is not yet on PyPI, but may be in the future.
+## install
 
-The following is the documentation from previous versions of this project, and has yet to be updated:
+`python -m pip install tkinterdnd2`
 
 ## usage
 
@@ -62,4 +63,5 @@ If you want to use pyinstaller, you should use the hook-tkinterdnd2.py file incl
 your project, then:
 
     pyinstaller -F -w myproject/myproject.py --additional-hooks-dir=.
+
 

--- a/tkinterdnd2/TkinterDnD.py
+++ b/tkinterdnd2/TkinterDnD.py
@@ -10,15 +10,14 @@ Once the TkinterDnD2 package is installed, it is safe to do:
 
 from TkinterDnD2 import *
 
-This will add the classes TkinterDnD.Tk and TkinterDnD.TixTk to the global
+This will add the classes TkinterDnD.Tk to the global
 namespace, plus the following constants:
 PRIVATE, NONE, ASK, COPY, MOVE, LINK, REFUSE_DROP,
 DND_TEXT, DND_FILES, DND_ALL, CF_UNICODETEXT, CF_TEXT, CF_HDROP,
 FileGroupDescriptor, FileGroupDescriptorW
 
 Drag and drop for the application can then be enabled by using one of the
-classes TkinterDnD.Tk() or (in case the tix extension shall be used)
-TkinterDnD.TixTk() as application main window instead of a regular
+classes TkinterDnD.Tk() as application main window instead of a regular
 tkinter.Tk() window. This will add the drag-and-drop specific methods to the
 Tk window and all its descendants.
 '''
@@ -278,3 +277,4 @@ class Tk(tkinter.Tk, DnDWrapper):
     def __init__(self, *args, **kw):
         tkinter.Tk.__init__(self, *args, **kw)
         self.TkdndVersion = _require(self)
+

--- a/tkinterdnd2/TkinterDnD.py
+++ b/tkinterdnd2/TkinterDnD.py
@@ -23,12 +23,7 @@ tkinter.Tk() window. This will add the drag-and-drop specific methods to the
 Tk window and all its descendants.
 '''
 
-try:
-    import Tkinter as tkinter
-    import Tix as tix
-except ImportError:
-    import tkinter
-    from tkinter import tix
+import tkinter
 
 TkdndVersion = None
 
@@ -282,11 +277,4 @@ class Tk(tkinter.Tk, DnDWrapper):
     DnDWrapper class apply to this window and all its descendants.'''
     def __init__(self, *args, **kw):
         tkinter.Tk.__init__(self, *args, **kw)
-        self.TkdndVersion = _require(self)
-
-class TixTk(tix.Tk, DnDWrapper):
-    '''Creates a new instance of a tix.Tk() window; all methods of the
-    DnDWrapper class apply to this window and all its descendants.'''
-    def __init__(self, *args, **kw):
-        tix.Tk.__init__(self, *args, **kw)
         self.TkdndVersion = _require(self)

--- a/tkinterdnd2/__init__.py
+++ b/tkinterdnd2/__init__.py
@@ -20,6 +20,5 @@ FileGroupDescriptorW = 'FileGroupDescriptorW - FileContents'# ??
 
 from . import TkinterDnD
 from .TkinterDnD import Tk
-from .TkinterDnD import TixTk
 
 


### PR DESCRIPTION
These suggested changes remove support for Tix. 

The why:

- Tix was depreciated in Python 3.6 and will be removed in Python 3.13 which will be released in full in October 2024. If Tix is not removed, it will result in runtime errors due to the current logic.
- Window handling was managed in the past by `Tk`. However, `Tix` was made to handle both windows and additional functionality. It was desirable to separate the window handling and the functionality, as a result, all the additional functionality was moved to `Ttk` and window handling functions were left to `Tk` alone. This is described in the documentation and quoted below:

> The basic idea for [tkinter.ttk](https://docs.python.org/3/library/tkinter.ttk.html#module-tkinter.ttk) is to separate, to the extent possible, the code implementing a widget’s behavior from the code implementing its appearance. ( Source: https://docs.python.org/3/library/tkinter.ttk.html#module-tkinter.ttk)

As a result, when removing Tix, we no longer need the extended class TixTk as all Window handling is managed by Tk.

In this Pull request, I am suggesting the removal of Tix completely. I had previously considered leaving it in to some degree for back compatibility, but due to the fact that it has been depreciated for 8 years and unmaintained for 10 years, it seems most appropriate to fully remove it in suit with Python 3.13. 

The changes were then tested with Python 3.10 and 3.13 to confirm that the changes had the desired result.

Please let me know if you have any questions or concerns.